### PR TITLE
Install python-six >= 1.7.0 before svc-mon starts

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -288,6 +288,7 @@ class contrail::config (
   ##
   # svcmon is only required for service chaining (service VMs). So only
   # configure it if $enable_svcmon is set.
+  # svcmon need python-six >= 1.7
   ##
   if $enable_svcmon {
     file {'/etc/contrail/svc-monitor.conf':
@@ -296,11 +297,13 @@ class contrail::config (
       require   => Package[$package_name]
     }
 
+    ensure_resource('package','python-six',{ensure => latest})
+
     service {'contrail-svc-monitor':
       ensure    => 'running',
       enable    => true,
       subscribe => File['/etc/contrail/svc-monitor.conf'],
-      require   => Package[$package_name]
+      require   => [Package[$package_name],Package['python-six']],
     }
   }
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -25,6 +25,7 @@ describe 'contrail::config' do
     it do
       should contain_package('contrail-config-openstack').with({'ensure' => 'present'})
       should contain_package('contrail-utils').with_ensure('present')
+      should contain_package('python-six').with_ensure('latest')
       should contain_package('neutron-plugin-contrail').with_ensure('present')
       should contain_file('/etc/contrail/ctrl-details').with_content( <<-CTRL.gsub(/^ {8}/, '')
         SERVICE_TOKEN=auth_password


### PR DESCRIPTION
svc-mon is dependant on python-six >= 1.7.0, so install it before the service
start.