### PR TITLE
Support for custom rabbitmq authentication

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -104,6 +104,12 @@
 # [*rabbit_port*]
 #  Rabbitmq port, Default: 5672
 #
+# [*rabbit_user*]
+#  Rabbitmq user, Default: guest
+#
+# [*rabbit_password*]
+#  Rabbitmq password, Default: guest
+#
 # [*discovery_listen*]
 #  The address on which discovery server to be listen.
 #
@@ -185,6 +191,8 @@ class contrail::config (
   $redis_ip                   = $::ipaddress,
   $rabbit_ip                  = $::ipaddress,
   $rabbit_port                = 5672,
+  $rabbit_user                = 'guest',
+  $rabbit_password            = 'guest',
   $discovery_listen           = '0.0.0.0',
   $discovery_local_listen_port= 9110,
   $discovery_server_port      = 5998,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,12 @@
 # [*rabbitmq_ip*]
 #  Rabbitmq server IP
 #
+# [*rabbit_user*]
+#  Rabbitmq Username to connect with. Defaults to `guest`
+#
+# [*rabbit_password*]
+#  Rabbitmq Password to connect with. Defaults to `guest`
+#
 # [*discovery_listen*]
 #  The address on which discovery server to be listen.
 #
@@ -227,6 +233,8 @@ class contrail (
   $zk_ip_list                 = [],
   $redis_ip                   =  undef,
   $rabbit_ip                  =  undef,
+  $rabbit_user                = 'guest',
+  $rabbit_password            = 'guest',
   $discovery_listen           = '0.0.0.0',
   $discovery_local_listen_port= 9110,
   $discovery_server_port      = 5998,
@@ -296,6 +304,8 @@ class contrail (
   validate_string($redis_ip)
   validate_string($collector_ip)
   validate_string($rabbit_ip)
+  validate_string($rabbit_user)
+  validate_string($rabbit_password)
   validate_string($config_package_name)
   validate_string($package_ensure)
   validate_string($keystone_protocol)
@@ -496,6 +506,8 @@ class contrail (
     zk_ip_list                 => $zk_ip_list_orig,
     redis_ip                   => $redis_ip_orig,
     rabbit_ip                  => $rabbit_ip_orig,
+    rabbit_user                => $rabbit_user,
+    rabbit_password            => $rabbit_password,
     discovery_listen           => $discovery_listen,
     discovery_local_listen_port=> $discovery_local_listen_port,
     discovery_server_port      => $discovery_server_port,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -57,6 +57,8 @@ describe 'contrail::config' do
         redis_server_ip=10.1.1.1
         rabbit_server=10.1.1.1
         rabbit_port=5672
+        rabbit_user=guest
+        rabbit_password=guest
 
         [SECURITY]
         use_certs=false

--- a/spec/classes/contrail_spec.rb
+++ b/spec/classes/contrail_spec.rb
@@ -53,6 +53,8 @@ describe 'contrail' do
         'zk_ip_list'                 => ['10.1.1.1'],
         'redis_ip'                   => '10.1.1.1',
         'rabbit_ip'                  => '10.1.1.1',
+        'rabbit_user'                => 'guest',
+        'rabbit_password'            => 'guest',
         'discovery_listen'           => '0.0.0.0',
         'discovery_local_listen_port'=> 9110,
         'discovery_server_port'      => 5998,
@@ -87,4 +89,24 @@ describe 'contrail' do
       should contain_class('contrail::repo')
     end
   end
+  
+  context 'with custom rabbitmq login' do
+    let :params do
+      {
+        :keystone_admin_token     => 'admin_token',
+        :keystone_admin_password  => 'admin_password',
+        :keystone_auth_password   => 'auth_password',
+        :rabbit_user              => 'someuser',
+        :rabbit_password          => 'somepassword',
+      }
+    end
+
+    it do 
+      should contain_class('contrail::config').with({
+        'rabbit_user'     => 'someuser',
+        'rabbit_password' => 'somepassword',
+      })
+    end
+  end
+
 end

--- a/templates/contrail-api.conf.erb
+++ b/templates/contrail-api.conf.erb
@@ -15,6 +15,8 @@ zk_server_ip=<%= @zk_ip_list.map{ |ip| "#{ip}:#{@zk_port}" }.join(',') %>
 redis_server_ip=<%= @redis_ip %>
 rabbit_server=<%= @rabbit_ip %>
 rabbit_port=<%= @rabbit_port %>
+rabbit_user=<%= @rabbit_user %>
+rabbit_password=<%= @rabbit_password %>
 
 [SECURITY]
 use_certs=<%= @use_certs %>


### PR DESCRIPTION
Contrail API authenticates to Rabbit MQ using `guest` by default.

This patch adds support for specifing a Rabbit MQ user/password
inorder to authenticate when using more secured MQ server.

Incase the Rabbitmq username/password is not specified, the module will
default to guest/guest.