### PR TITLE
Create floating ip pool using contrail api

### DIFF
--- a/lib/puppet/provider/contrail_fip_pool/provisioner.rb
+++ b/lib/puppet/provider/contrail_fip_pool/provisioner.rb
@@ -1,0 +1,56 @@
+require_relative '../contrailBGP'
+
+Puppet::Type.type(:contrail_fip_pool).provide(
+  :provisioner,
+  :parent => Puppet::Provider::ContrailBGP
+) do
+
+  commands  :create_fip => '/usr/share/contrail-utils/create_floating_pool.py',
+            :use_fip => '/usr/share/contrail-utils/use_floating_pool.py'
+
+  def getUrl
+    'http://' + resource[:api_server_address] + ':' + resource[:api_server_port] + '/floating-ip-pools'
+  end
+
+  def exists?
+    !getObject(getUrl,"#{resource[:network_fqname]}:#{resource[:name]}").nil?
+  end
+
+  def getObject(url,name)
+    getUrlData(url)['floating-ip-pools'].each do |i|
+      if i['fq_name'].join(':') == name
+        @fip_obj = getUrlData(i['href'])['floating-ip-pool']['project_back_refs']
+      end
+    end
+    return  @fip_obj
+  end
+
+  def create
+    create_fip('--public_vn_name',resource[:network_fqname],'--floating_ip_pool_name',resource[:name])
+    resource[:tenants].each do |x|
+      use_fip('--project_name', "default-domain:#{x}", '--floating_ip_pool_name',"#{resource[:network_fqname]}:#{resource[:name]}")
+    end
+  end
+
+  ##
+  #TODO: as of now existing fip pool is not supported. it need more investigation and testing to avoid contrail stale data.
+  ##
+  def destroy
+    fail('Destroying fip pool is not supported using contrail api')
+  end
+
+  def tenants
+    getObject(getUrl,resource[:name]).collect { |x| x['to'].last}
+  end
+
+  ##
+  # TODO: As of now, removal of existing tenant from a fip pool is not supported, it need more investigation to enable it.
+  ##
+  def tenants=(value)
+    tenants_to_add = resource[:tenants] - getObject(getUrl,resource[:name]).collect { |x| x['to'].join(':')}
+    tenants_to_add.each do |x|
+      use_fip('--project_name', "default-domain:#{x}", '--floating_ip_pool_name',"#{resource[:network_fqname]}:#{resource[:name]}")
+    end
+  end
+
+end

--- a/lib/puppet/type/contrail_fip_pool.rb
+++ b/lib/puppet/type/contrail_fip_pool.rb
@@ -1,0 +1,56 @@
+Puppet::Type.newtype(:contrail_fip_pool) do
+
+  @doc = <<-'EOD'
+  Provision floating ips using contrail apis and provide access to certain projects.
+This is required if you need a floating IP pool which are only shared to specific tenants.
+If you use neutron apis, the floating IP pool will be shared with all tenants.
+
+  example:
+
+  ## Below code will create floating ip with access to the tenants, tenant1, tenant2
+
+  contrail_fip_pool {'fip1':
+    ensure         => present,
+    network_fqname => default-domain:tenant:fip_net1,
+    tenants        => ['tenant1','tenant2'],
+  }
+
+  EOD
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc 'Floating ip pool name'
+    munge do |v|
+      v.strip
+    end
+  end
+
+  newparam(:network_fqname) do
+    desc 'Fully qualified name for network on which the fip pool to be created.'
+  end
+
+  newparam(:api_server_address) do
+    desc 'Contrail api server address'
+    defaultto '127.0.0.1'
+    munge do |v|
+      v.strip
+    end
+  end
+
+  newparam(:api_server_port) do
+    desc 'Contrail api server port'
+    defaultto 8082
+    newvalues(/^\d+$/)
+    munge do |v|
+      v.to_s
+    end
+  end
+
+  newproperty(:tenants, :array_matching => :all) do
+    desc 'An array of project fqnames which will have access to this fip pool'
+    def insync?(is)
+      is.sort == should.sort
+    end
+  end
+end


### PR DESCRIPTION
Using contrail api is required to create floating ip pool which is restricted to
specific tenants. Using neutron api is not possible, as in that case, fip pool
is shared to all tenants.