### PR TITLE
Added openstack services details to configuration for webui

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,11 +20,13 @@
 #  Keystone service user password
 #
 # [*keystone_admin_port*]
-#  Keystone admin port
+#  Keystone admin port, default to 35357
 #
 # [*keystone_protocol*]
-#  Keystone protocol
+#  Keystone protocol, default to http
 #
+# [*keystone_port*]
+# Keystone port - defaults to 5000
 # [*haproxy_enabled*]
 #  Whether to enable local haproxy or not.
 # Note: in case local haproxy enabled, all contrail servers will have one
@@ -152,6 +154,33 @@
 #   Specifies that the current node is the seed node. Only the seed node
 #   creates objects using the API to avoid race conditions.
 #
+# [*glance_address*]
+#  Glance address
+#
+# [*glance_port*]
+#  Glance api port, default to 9292
+#
+# [*glance_protocol*]
+#  Glance api protocol, default to http
+#
+# [*nova_address*]
+#  Nova Address
+#
+# [*nova_port*]
+#  Nova port, default to 8774
+#
+# [*nova_protocol*]
+#  Nova protocol, default to http
+#
+# [*cinder_address*]
+#  Cinder address
+#
+# [*cinder_port*]
+#  Cinder port, default to 8776
+#
+# [*cinder_protocol*]
+#  Cinder protocol, default to http
+#
 # === Examples
 #
 #  class {'::contrail':
@@ -174,7 +203,6 @@ class contrail (
   $keystone_auth_password,
   $router_ip                  = undef,
   $router_name                = 'router1',
-  $keystone_address           = undef,
   $nova_metadata_address      = undef,
   $nova_metadata_port         = 8775,
   $interface                  = 'eth0',
@@ -183,8 +211,6 @@ class contrail (
   $control_ip_list            = [],
   $config_package_name        = 'contrail-config-openstack',
   $package_ensure             = 'present',
-  $keystone_admin_port        = 35357,
-  $keystone_protocol          = 'http',
   $haproxy_enabled            = true,
   $neutron_ip                 = undef,
   $neutron_port               = 9697,
@@ -211,6 +237,24 @@ class contrail (
   $collector_ip               = undef,
   $router_asn                 = 64512,
   $seed                       = true,
+
+  $keystone_address           = undef,
+  $keystone_admin_port        = 35357,
+  $keystone_port              = 5000,
+  $keystone_protocol          = 'http',
+
+  $glance_address             = undef,
+  $glance_port                = 9292,
+  $glance_protocol            = http,
+
+  $nova_address               = undef,
+  $nova_port                  = 8774,
+  $nova_protocol              = http,
+
+  $cinder_address             = undef,
+  $cinder_port                = 8776,
+  $cinder_protocol            = http,
+
 ) {
 
   ##
@@ -232,11 +276,18 @@ class contrail (
   validate_re($discovery_local_listen_port, '\d+')
   validate_re($discovery_server_port, '\d+')
   validate_re($cassandra_port, '\d+')
+  validate_re($keystone_port, '\d+')
+  validate_re($glance_port, '\d+')
+  validate_re($cinder_port, '\d+')
+  validate_re($nova_port, '\d+')
   validate_re($analytics_data_ttl, '\d+')
   validate_re($hc_interval, '\d+')
   validate_re($router_asn, '\d+')
   validate_re($nova_metadata_port, '\d+')
   validate_string($keystone_address)
+  validate_string($glance_address)
+  validate_string($cinder_address)
+  validate_string($nova_address)
   validate_string($nova_metadata_address)
   validate_string($keystone_region)
   validate_string($keystone_admin_token)
@@ -248,6 +299,9 @@ class contrail (
   validate_string($config_package_name)
   validate_string($package_ensure)
   validate_string($keystone_protocol)
+  validate_string($glance_protocol)
+  validate_string($cinder_protocol)
+  validate_string($nova_protocol)
   validate_string($neutron_ip)
   validate_string($neutron_protocol)
   validate_string($config_ip)
@@ -299,6 +353,24 @@ class contrail (
     $keystone_address_orig = $contrail_ip
   } else {
     $keystone_address_orig = $keystone_address
+  }
+
+  if ! $glance_address {
+    $glance_address_orig = $contrail_ip
+  } else {
+    $glance_address_orig = $glance_address
+  }
+
+  if ! $cinder_address {
+    $cinder_address_orig = $contrail_ip
+  } else {
+    $cinder_address_orig = $cinder_address
+  }
+
+  if ! $nova_address {
+    $nova_address_orig = $contrail_ip
+  } else {
+    $nova_address_orig = $nova_address
   }
 
   if empty($control_ip_list) {
@@ -482,10 +554,20 @@ class contrail (
     analytics_data_ttl  => $analytics_data_ttl,
     cassandra_ip_list   => $cassandra_ip_list_orig,
     redis_ip            => $redis_ip_orig,
-    glance_address      => $keystone_address_orig,
-    nova_address        => $keystone_address_orig,
+    glance_address      => $glance_address_orig,
+    glance_port         => $glance_port,
+    glance_protocol     => $glance_protocol,
+    nova_address        => $nova_address_orig,
+    nova_port           => $nova_port,
+    nova_protocol       => $nova_protocol,
     keystone_address    => $keystone_address_orig,
-    cinder_address      => $keystone_address_orig,
+    keystone_port       => $keystone_port,
+    keystone_protocol   => $keystone_protocol,
+    cinder_address      => $cinder_address_orig,
+    cinder_port         => $cinder_port,
+    cinder_protocol     => $cinder_protocol,
+    neutron_port        => $neutron_port,
+    neutron_protocol    => $neutron_protocol,
     collector_ip        => $collector_ip_orig,
   }
 

--- a/manifests/webui.pp
+++ b/manifests/webui.pp
@@ -11,6 +11,24 @@ class contrail::webui (
   $contrail_ip        = $::ipaddress,
   $webui_ip           = $::ipaddress,
   $config_ip          = $::ipaddress,
+  $neutron_port       = 9696,
+  $neutron_protocol   = http,
+  $glance_address     = $::ipaddress,
+  $glance_port        = 9292,
+  $glance_protocol    = http,
+
+  $nova_address       = $::ipaddress,
+  $nova_port          = 8774,
+  $nova_protocol      = http,
+
+  $keystone_address   = $::ipaddress,
+  $keystone_port      = 5000,
+  $keystone_protocol  = http,
+
+  $cinder_address     = $::ipaddress,
+  $cinder_port        = 8776,
+  $cinder_protocol    = http,
+
   $analytics_data_ttl = 48, ## Number of hours to keep the data
   $cassandra_ip_list  = [$::ipaddress],
   $redis_ip           = $::ipaddress,

--- a/templates/config.global.js.erb
+++ b/templates/config.global.js.erb
@@ -74,32 +74,32 @@ config.serviceEndPointTakePublicURL = true;
 *****************************************************************************/
 config.networkManager = {};
 config.networkManager.ip = '<%= @config_ip %>';
-config.networkManager.port = '9696'
-config.networkManager.authProtocol = 'http';
+config.networkManager.port = '<%= @neutron_port %>'
+config.networkManager.authProtocol = '<%= @neutron_protocol %>';
 config.networkManager.apiVersion = [];
 config.networkManager.strictSSL = false;
 config.networkManager.ca = '';
 
 config.imageManager = {};
 config.imageManager.ip = '<%= @glance_address %>';
-config.imageManager.port = '9292';
-config.imageManager.authProtocol = 'http';
+config.imageManager.port = '<%= @glance_port %>';
+config.imageManager.authProtocol = '<%= @glance_protocol %>';
 config.imageManager.apiVersion = ['v1', 'v2'];
 config.imageManager.strictSSL = false;
 config.imageManager.ca = '';
 
 config.computeManager = {};
 config.computeManager.ip = '<%= @nova_address %>';
-config.computeManager.port = '8774';
-config.computeManager.authProtocol = 'http';
+config.computeManager.port = '<%= @nova_port %>';
+config.computeManager.authProtocol = '<%= @nova_protocol %>';
 config.computeManager.apiVersion = ['v1.1', 'v2'];
 config.computeManager.strictSSL = false;
 config.computeManager.ca = '';
 
 config.identityManager = {};
 config.identityManager.ip = '<%= @keystone_address %>';
-config.identityManager.port = '5000';
-config.identityManager.authProtocol = 'http';
+config.identityManager.port = '<%= @keystone_port %>';
+config.identityManager.authProtocol = '<%= @keystone_protocol %>';
 /******************************************************************************
  * Note: config.identityManager.apiVersion is not controlled by boolean flag 
  * config.serviceEndPointFromConfig. If specified apiVersion here, then these
@@ -113,8 +113,8 @@ config.identityManager.ca = '';
 
 config.storageManager = {};
 config.storageManager.ip = '<%= @cinder_address %>';
-config.storageManager.port = '8776';
-config.storageManager.authProtocol = 'http';
+config.storageManager.port = '<%= @cinder_port %>';
+config.storageManager.authProtocol = '<%= @cinder_protocol %>';
 config.storageManager.apiVersion = ['v1'];
 config.storageManager.strictSSL = false;
 config.storageManager.ca = '';


### PR DESCRIPTION
webui need endpoint details for all openstack services which was hardcoded in
webui configuration which was causing issue as the protocol was hardcoded to
http where we use https. This is causing webui to fail. This patch fix that by
accepting them as params.