### PR TITLE
Workaround to provided execute permission to contrail-utils scripts

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -216,6 +216,17 @@ class contrail::config (
   }
 
   ##
+  # This is a workaround to make the scripts under /usr/share/contrail-utils
+  # executable, due to a bug in the contrail packaging, some of the files do not
+  # have execute permission
+  ##
+  file {'/usr/share/contrail-utils/':
+    mode    => '755',
+    recurse => true,
+    require => Package['contrail-utils'],
+  }
+
+  ##
   ## Ensure ctrl-details file is present with right content.
   ##
   file { '/etc/contrail/ctrl-details' :


### PR DESCRIPTION
Due to a bug in contrail-utils packaging, there are some of the files under
/usr/share/contrail-utils does not have execute permission, this patch is to fix
that.

Because of this issue, contrail_fip_pool provider is breaking.