### PR TITLE
Block contrail dns service unless enabled

### DIFF
--- a/files/contrail-named.ini
+++ b/files/contrail-named.ini
@@ -1,0 +1,13 @@
+[program:contrail-named]
+command=/usr/bin/authbind /usr/bin/contrail-named -f -c /etc/contrail/dns/named.conf
+user=contrail
+priority=520
+autostart=true
+killasgroup=true
+stopsignal=KILL
+stdout_capture_maxbytes=1MB
+startsecs=5
+redirect_stderr=true
+stdout_logfile=/var/log/contrail/contrail-named-stdout.log
+stderr_logfile=/var/log/contrail/contrail-named.err
+exitcodes=0                   ; 'expected' exit codes for process (default 0,2)

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -9,30 +9,55 @@ class contrail::control (
   $log_level       = 'SYS_INFO',
   $log_file_size   = 10737418240,
   $log_local       = 1,
+  $enable_dns      = false,
+  $dns_port        = '10000'
 ) {
 
   package {'contrail-control':
     ensure => $package_ensure,
   }
 
-
-  package {'contrail-dns':
-    ensure => $package_ensure,
-  }
+  if $enable_dns {
+    package {'contrail-dns':
+      ensure => $package_ensure,
+    }
   ##
   # DNS configuration
   ##
 
-  file { '/etc/contrail/dns.conf' :
-    ensure  => present,
-    content => template("${module_name}/dns.conf.erb"),
-  }
+    file { '/etc/contrail/dns.conf' :
+      ensure  => present,
+      content => template("${module_name}/dns.conf.erb"),
+    }
 
-  service {'contrail-dns':
-    ensure    => running,
-    enable    => true,
-    subscribe => File['/etc/contrail/dns.conf'],
-    require   => Package['contrail-dns']
+  ##
+  # Contrail Named Configuration
+  ##
+
+    file { '/etc/contrail/supervisord_control_files/contrail-named.ini' :
+      ensure => present,
+      source => "puppet:///modules/${module_name}/contrail-named.ini"
+    }
+
+    file { '/etc/contrail/dns/named.conf' :
+      ensure  => present,
+      content => template("${module_name}/contrail-named.conf.erb"),
+    }
+
+    service {'contrail-named':
+      ensure    => running,
+      enable    => true,
+      subscribe => [ File['/etc/contrail/dns/named.conf'],
+                File['/etc/contrail/supervisord_control_files/contrail-named.ini'] ],
+      require   => Package['contrail-dns']
+    }
+
+    service {'contrail-dns':
+      ensure    => running,
+      enable    => true,
+      subscribe => File['/etc/contrail/dns.conf'],
+      require   => Package['contrail-dns']
+    }
   }
 
   ##

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -202,6 +202,14 @@
 #  Enable ifmap, defaults to true. Ifmap is not required to be setup in case of
 #  a separate node which is only running contrail analytics.
 #
+# [*enable_dns*] 
+#  Enable contrail dns service , defaults to false. Contrail dns service can be placed on a
+#  seperate node
+#
+#
+# [*dns_port]
+#  The port on which contrail-named service listens, by default this is set to 10000
+#
 # === Examples
 #
 #  class {'::contrail':
@@ -282,6 +290,8 @@ class contrail (
   $enable_control              = true,
   $enable_webui                = true,
   $enable_ifmap                = true,
+  $enable_dns                  = false,
+  $dns_port                    = '10000'
 ) {
 
   ##
@@ -562,6 +572,8 @@ class contrail (
       control_ip_list => $control_ip_list_orig,
       config_ip       => $config_ip_orig,
       contrail_ip     => $contrail_ip,
+      enable_dns      => $enable_dns,
+      dns_port        => $dns_port
     }
 
     Anchor['contrail::end_base_services'] ->

--- a/spec/classes/control_spec.rb
+++ b/spec/classes/control_spec.rb
@@ -17,6 +17,27 @@ describe 'contrail::control' do
   context 'with defaults' do
     it do
       should contain_package('contrail-control').with({'ensure' => 'present'})
+      should contain_file('/etc/contrail/contrail-control.conf').with_content(/hostip=10.1.1.1/)
+      should contain_file('/etc/contrail/contrail-control.conf').with_content(/hostname=node1/)
+      should contain_file('/etc/contrail/contrail-control.conf').with_content(/server=10.1.1.1/)
+      should contain_file('/etc/contrail/contrail-control.conf').with_content(/password=10.1.1.1/)
+      should contain_file('/etc/contrail/contrail-control.conf').with_content(/user=10.1.1.1/)
+      should contain_service('contrail-control').with({
+        'ensure'    => 'running',
+        'enable'    => true,
+        'subscribe' => 'File[/etc/contrail/contrail-control.conf]',
+        'require'   => 'Package[contrail-control]'
+      })
+    end
+  end
+  context 'with contrail-dns' do
+    let :params do
+      {
+      :enable_dns => true,
+      :dns_port   => '10000',
+      }
+    end
+    it do
       should contain_package('contrail-dns').with({'ensure' => 'present'})
       should contain_file('/etc/contrail/dns.conf').with_content(/hostip=10.1.1.1/)
       should contain_file('/etc/contrail/dns.conf').with_content(/hostname=node1/)
@@ -29,16 +50,13 @@ describe 'contrail::control' do
         'subscribe' => 'File[/etc/contrail/dns.conf]',
         'require'   => 'Package[contrail-dns]'
       })
-      should contain_file('/etc/contrail/contrail-control.conf').with_content(/hostip=10.1.1.1/)
-      should contain_file('/etc/contrail/contrail-control.conf').with_content(/hostname=node1/)
-      should contain_file('/etc/contrail/contrail-control.conf').with_content(/server=10.1.1.1/)
-      should contain_file('/etc/contrail/contrail-control.conf').with_content(/password=10.1.1.1/)
-      should contain_file('/etc/contrail/contrail-control.conf').with_content(/user=10.1.1.1/)
-      should contain_service('contrail-control').with({
+      should contain_file('/etc/contrail/dns/named.conf').with_content(/listen-on port 10000/)
+      should contain_file('/etc/contrail/supervisord_control_files/contrail-named.ini')
+      should contain_service('contrail-named').with({
         'ensure'    => 'running',
         'enable'    => true,
-        'subscribe' => 'File[/etc/contrail/contrail-control.conf]',
-        'require'   => 'Package[contrail-control]'
+        'subscribe' => '[File[/etc/contrail/dns/named.conf]{:path=>"/etc/contrail/dns/named.conf"}, File[/etc/contrail/supervisord_control_files/contrail-named.ini]{:path=>"/etc/contrail/supervisord_control_files/contrail-named.ini"}]',
+        'require'   => 'Package[contrail-dns]'
       })
     end
   end

--- a/templates/contrail-named.conf.erb
+++ b/templates/contrail-named.conf.erb
@@ -1,0 +1,45 @@
+##This file is managed by Puppet ##
+options {
+    directory "/etc/contrail/dns/";
+    managed-keys-directory "/etc/contrail/dns/";
+    empty-zones-enable no;
+    pid-file "/etc/contrail/dns/contrail-named.pid";
+    listen-on port <%= @dns_port %> { any; };
+    allow-query { any; };
+    allow-recursion { any; };
+    allow-query-cache { any; };
+};
+
+key "rndc-key" {
+    algorithm hmac-md5;
+    secret "xvysmOR8lnUQRBcunkC6vg==";
+};
+
+controls {
+    inet 127.0.0.1 port 8094
+    allow { 127.0.0.1; }  keys { "rndc-key"; };
+};
+
+logging {
+    channel debug_log {
+        file "/var/log/contrail/contrail-named.log" versions 3 size 5m;
+        severity debug;
+        print-time yes;
+        print-severity yes;
+        print-category yes;
+    };
+    category default {
+        debug_log;
+    };
+    category queries {
+        debug_log;
+    };
+};
+
+view "_default_view_" {
+    match-clients {any;};
+    match-destinations {any;};
+    match-recursive-only no;
+    forwarders {127.0.0.1; };
+};
+


### PR DESCRIPTION
In v2.1 Contrail installs bind service on contrail controller this will disrupt the dnsmasq , hence adding a flag to disable contrail-dns as we are not using this service for now.