### PR TITLE
Fixed Create Floating IP issue

### DIFF
--- a/lib/puppet/provider/contrail_fip_pool/provisioner.rb
+++ b/lib/puppet/provider/contrail_fip_pool/provisioner.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:contrail_fip_pool).provide(
   end
 
   def create
-    create_fip('--public_vn_name',resource[:network_fqname],'--floating_ip_pool_name',resource[:name])
+    create_fip('--public_vn_name',resource[:network_fqname],'--floating_ip_pool_name',resource[:name],'--api_server_ip',resource[:api_server_address],'--api_server_port',resource[:api_server_port],'--admin_user',resource[:admin_user],'--admin_password',resource[:admin_password],'--admin_tenant',resource[:admin_tenant])
     resource[:tenants].each do |x|
       use_fip('--project_name', "default-domain:#{x}", '--floating_ip_pool_name',"#{resource[:network_fqname]}:#{resource[:name]}")
     end

--- a/lib/puppet/type/contrail_fip_pool.rb
+++ b/lib/puppet/type/contrail_fip_pool.rb
@@ -47,6 +47,31 @@ If you use neutron apis, the floating IP pool will be shared with all tenants.
     end
   end
 
+  newparam(:admin_user) do
+    desc 'Openstack Admin User'
+    defaultto 'admin'
+    munge do |v|
+      v.strip
+    end
+  end
+
+  newparam(:admin_password) do
+    desc 'Openstack Admin Password'
+    defaultto 'Chang3M3'
+    munge do |v|
+      v.strip
+    end
+  end
+
+  newparam(:admin_tenant) do
+    desc 'Openstack Admin Tenant'
+    defaultto 'openstack'
+    munge do |v|
+      v.strip
+    end
+  end
+
+
   newproperty(:tenants, :array_matching => :all) do
     desc 'An array of project fqnames which will have access to this fip pool'
     def insync?(is)


### PR DESCRIPTION
create-floating-ip.py now requires the following attributes

*api_server_ip
*api_server_port
*admin_user
*admin_password
*admin_tenant
Made the necessary changes to accommodate the above.