### PR TITLE
Changed apt pin for nodejs to version contrail1

### DIFF
--- a/manifests/webui.pp
+++ b/manifests/webui.pp
@@ -45,13 +45,13 @@ class contrail::webui (
   }
 
   ##
-  # Contrail webui need older version of (0.8.x) nodejs.
+  # Contrail webui need a specific version of >= (0.8-contrail1) nodejs.
   # So pinning it on contrail node.
   ##
   apt::pin {'nodejs_for_contrail_webui':
     priority => 1001,
     packages => 'nodejs',
-    version  => '0.8*'
+    version  => '*contrail1'
   }
 
   Apt::Pin<||> -> Package<||>

--- a/spec/classes/webui_spec.rb
+++ b/spec/classes/webui_spec.rb
@@ -31,7 +31,7 @@ describe 'contrail::webui' do
       should contain_apt__pin('nodejs_for_contrail_webui').with({
         'priority' => 1001,
         'packages' => 'nodejs',
-        'version'  => '0.8*'
+        'version'  => '*contrail1'
       })
     end
   end


### PR DESCRIPTION
Currently nodejs version was apt-pinned to 0.8.* version. In 2.1 they have changed the dependency to include a contrail specific nodejs version which is now being directly built by contrail. It has contrail1 appended to its version